### PR TITLE
Enable building on 3.13

### DIFF
--- a/durus/__init__.py
+++ b/durus/__init__.py
@@ -1,4 +1,4 @@
 """
 Copyright (c) Corporation for National Research Initiatives 2009. All Rights Reserved.
 """
-__version__ = '4.2'
+__version__ = '4.3'

--- a/durus/_persistent.c
+++ b/durus/_persistent.c
@@ -55,12 +55,20 @@ static void
 pb_dealloc(PersistentBaseObject *self) 
 {
 	PyObject_GC_UnTrack(self);
+#if PY_VERSION_HEX < 0x03080000
 	Py_TRASHCAN_SAFE_BEGIN(self);
+#else
+    Py_TRASHCAN_BEGIN(self, pb_dealloc);
+#endif
 	Py_XDECREF(self->p_connection);
 	Py_XDECREF(self->p_oid);
 	Py_XDECREF(self->p_serial);
 	PyObject_GC_Del(self);
+#if PY_VERSION_HEX < 0x03080000
 	Py_TRASHCAN_SAFE_END(self); 
+#else
+    Py_TRASHCAN_END;
+#endif
 }
 
 static int
@@ -286,10 +294,18 @@ static void
 cb_dealloc(ConnectionBaseObject *self) 
 {
 	PyObject_GC_UnTrack(self);
+#if PY_VERSION_HEX < 0x03080000
 	Py_TRASHCAN_SAFE_BEGIN(self);
+#else
+    Py_TRASHCAN_BEGIN(self, cb_dealloc);
+#endif
 	Py_XDECREF(self->transaction_serial);
 	PyObject_GC_Del(self);
-	Py_TRASHCAN_SAFE_END(self); 
+#if PY_VERSION_HEX < 0x03080000
+	Py_TRASHCAN_SAFE_END(self);
+#else
+    Py_TRASHCAN_END;
+#endif
 }
 
 static PyMemberDef cb_members[] = {


### PR DESCRIPTION
Py_TRASHCAN_SAFE_BEGIN/END macros were deprecated in 3.11 and removed in 3.13.

https://github.com/python/cpython/issues/105111
